### PR TITLE
Fixed undesired animation delay under certain circumstances 

### DIFF
--- a/Sources/UIView+KeepLayout.m
+++ b/Sources/UIView+KeepLayout.m
@@ -547,7 +547,8 @@
     if (duration > 0 || delay > 0) {
         [[NSOperationQueue mainQueue] performSelector:@selector(addOperationWithBlock:)
                                            withObject:block
-                                           afterDelay:delay];
+                                           afterDelay:delay
+                                              inModes:@[NSRunLoopCommonModes]];
     }
     else {
         block();


### PR DESCRIPTION
Trying to fix problem whereas default animations of UI object ran in a different runLoop causing undesirable animation delays in certain circumstances
