### PR TITLE
Expression is not an integer constant expression

### DIFF
--- a/Sources/KeepTypes.h
+++ b/Sources/KeepTypes.h
@@ -21,12 +21,11 @@
 
 #pragma mark Priority
 /// Use custom names.
-typedef enum : NSInteger {
-    KeepPriorityRequired = (int)UILayoutPriorityRequired,
-    KeepPriorityHigh = (int)UILayoutPriorityDefaultHigh,
-    KeepPriorityLow = (int)UILayoutPriorityDefaultLow,
-    KeepPriorityFitting = (int)UILayoutPriorityFittingSizeLevel,
-} KeepPriority;
+typedef float KeepPriority;
+static const KeepPriority KeepPriorityRequired = UILayoutPriorityRequired;
+static const KeepPriority KeepPriorityHigh = UILayoutPriorityDefaultHigh;
+static const KeepPriority KeepPriorityLow = UILayoutPriorityDefaultLow;
+static const KeepPriority KeepPriorityFitting = UILayoutPriorityFittingSizeLevel;
 
 extern NSString *KeepPriorityDescription(KeepPriority);
 


### PR DESCRIPTION
Fix error "Expression is not an integer constant expression" on iOS 8 beta 3

![screen shot 2014-07-08 at 01 56 53](https://cloud.githubusercontent.com/assets/489138/3503535/e3f7dc06-0632-11e4-8671-b339b615d978.png)
