### PR TITLE
Fix for ability to use priority calculations inside KeppAt macros

### DIFF
--- a/Sources/KeepTypes.h
+++ b/Sources/KeepTypes.h
@@ -87,7 +87,7 @@ extern double KeepValueGetPriority(KeepValue);
 extern KeepValue KeepValueSetDefaultPriority(KeepValue, KeepPriority);
 
 /// Use these macros to build KeepValues easily: x = 10 keepHigh;
-#define keepAt(Priority)    +(Priority * 1i)
+#define keepAt(Priority)    +((Priority) * 1i)
 #define keepRequired        keepAt(KeepPriorityRequired)
 #define keepHigh            keepAt(KeepPriorityHigh)
 #define keepLow             keepAt(KeepPriorityLow)


### PR DESCRIPTION
Small fix that allow to calculate priorities inside keepAr macros

```
    self.logoImageView.keepTopInset.equal = 70 keepAt(KeepPriorityHigh - 1);
```

From time to time I'm using these kind of constructions, when priority is specified by constant, and some of them just +1/-1 from the original one.:)
