### PR TITLE
Use legacy methods to disable UIView animations for iOS 6 in keepNotAnimated:

### DIFF
--- a/Sources/KeepView.h
+++ b/Sources/KeepView.h
@@ -329,10 +329,11 @@ typedef KeepAttribute *(^KeepRelatedAttributeBlock)(KPView *otherView);
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000   // Compiled with iOS 7 SDK
 /// Animate layout changes with spring behavior, delay, options and completion. Receiver automatically calls `-layoutIfNeeded` after the animation block. Animation is scheduled on Main Queue with given delay.
 - (void)keepAnimatedWithDuration:(NSTimeInterval)duration delay:(NSTimeInterval)delay usingSpringWithDamping:(CGFloat)dampingRatio initialSpringVelocity:(CGFloat)velocity options:(UIViewAnimationOptions)options layout:(void (^)(void))animations completion:(void (^)(BOOL finished))completion;
+#endif
 
 /// Prevent animating layout changes in the block. Due to different nature of constraint-based layouting, this may not work as you may expect.
 - (void)keepNotAnimated:(void (^)(void))layout;
-#endif
+
 #endif // TARGET_OS_IPHONE
 
 

--- a/Sources/KeepView.m
+++ b/Sources/KeepView.m
@@ -909,9 +909,9 @@
 }
 
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000   // Compiled with iOS 7 SDK
 - (void)keepNotAnimated:(void (^)(void))layout {
     
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000   // Compiled with iOS 7 SDK
     if ([UIView respondsToSelector:@selector(performWithoutAnimation:)]) {
         // Running iOS 7
         [UIView performWithoutAnimation:^{
@@ -919,8 +919,10 @@
             [self layoutIfNeeded];
         }];
     }
-    else {
-        // Running iOS 6, use legacy methods
+    else
+#endif
+    {
+        // Running iOS 6 or earlier, use legacy methods
         BOOL wereAnimationsEnabled = [UIView areAnimationsEnabled];
         [UIView setAnimationsEnabled: NO];
         
@@ -930,7 +932,6 @@
         [UIView setAnimationsEnabled: wereAnimationsEnabled];
     }
 }
-#endif
 
 #endif // TARGET_OS_IPHONE
 


### PR DESCRIPTION
iOS 6 is probably not that relevant nowdays, but wouldn't it be better to provide consistent behavior when the `performWithoutAnimation:` method is unavailable?

As per documentation for `setAnimationsEnabled:`

> This method affects only those animations that are submitted after it is called. If you call this method while existing animations are running, those animations continue running until they reach their natural end point.

So it looks like the behavior would be essentially the same as with the block-based `performWithoutAnimation:` call. 

It also seems like the whole `keepNotAnimated:` method could be enabled for any iOS version with this change, but I'm not sure if there were other reasons to wrap it in the `__IPHONE_OS_VERSION_MAX_ALLOWED` check.
