### PR TITLE
Divided Swift and ObjC library, added deployment  targets.

### DIFF
--- a/KeepLayout.podspec
+++ b/KeepLayout.podspec
@@ -30,9 +30,8 @@ Pod::Spec.new do |s|
     op.osx.exclude_files = 'Sources/UIViewController+KeepLayout.{h,m}', 'Sources/UIScrollView+KeepLayout.{h,m}'
   end
   s.subspec 'Swift' do |sp|
-    #sp.dependency 'KeepLayout/ObjC'
-    sp.source_files = 'Sources'
-    #sp.source_files = 'Sources/*.{swift}'
+    sp.dependency 'KeepLayout/ObjC'
+    sp.source_files = 'Sources/*.{swift}'
     sp.ios.deployment_target = '8.0'
     sp.osx.deployment_target = '10.9'
     sp.tvos.deployment_target = '9.0'

--- a/KeepLayout.podspec
+++ b/KeepLayout.podspec
@@ -9,11 +9,36 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/Tricertops/KeepLayout.git", :tag => "v1.7.0" }
 
-  s.source_files = 'Sources'
   s.requires_arc = true
 
-  s.ios.deployment_target = '5.0'
-  s.osx.deployment_target = '10.7'
+  s.module_name = "KeepLayout"
+  s.default_subspec = 'Swift'
+
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.9'
   s.tvos.deployment_target = '9.0'
 
+  s.subspec 'ObjC' do |op|
+    op.source_files = 'Sources'
+    op.exclude_files = 'Sources/*.{swift}'
+    op.ios.deployment_target = '5.0'
+    op.osx.deployment_target = '10.7'
+    op.tvos.deployment_target = '9.0'
+    op.ios.framework = 'UIKit'
+    op.tvos.framework = 'UIKit'
+    op.osx.framework = 'Cocoa'
+    op.osx.exclude_files = 'Sources/UIViewController+KeepLayout.{h,m}', 'Sources/UIScrollView+KeepLayout.{h,m}'
+  end
+  s.subspec 'Swift' do |sp|
+    #sp.dependency 'KeepLayout/ObjC'
+    sp.source_files = 'Sources'
+    #sp.source_files = 'Sources/*.{swift}'
+    sp.ios.deployment_target = '8.0'
+    sp.osx.deployment_target = '10.9'
+    sp.tvos.deployment_target = '9.0'
+    sp.ios.framework = 'UIKit'
+    sp.tvos.framework = 'UIKit'
+    sp.osx.framework = 'Cocoa'
+    sp.osx.exclude_files = 'Sources/UIViewController+KeepLayout.{h,m}', 'Sources/UIScrollView+KeepLayout.{h,m}'
+  end
 end

--- a/KeepLayout.podspec
+++ b/KeepLayout.podspec
@@ -11,4 +11,9 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Sources'
   s.requires_arc = true
+
+  s.ios.deployment_target = '5.0'
+  s.osx.deployment_target = '10.7'
+  s.tvos.deployment_target = '9.0'
+
 end


### PR DESCRIPTION
Added deployment targets for any supported platform. 
Added subspec for the ObjC library and for the Swift library.
Use Swift  subspec as a default spec. 